### PR TITLE
fix: remove nix-colors, add stylix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,19 +22,71 @@
         "url": "https://codeberg.org/LGFae/awww"
       }
     },
-    "base16-schemes": {
+    "base16": {
+      "inputs": {
+        "fromYaml": "fromYaml"
+      },
+      "locked": {
+        "lastModified": 1755819240,
+        "narHash": "sha256-qcMhnL7aGAuFuutH4rq9fvAhCpJWVHLcHVZLtPctPlo=",
+        "owner": "SenchoPens",
+        "repo": "base16.nix",
+        "rev": "75ed5e5e3fce37df22e49125181fa37899c3ccd6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SenchoPens",
+        "repo": "base16.nix",
+        "type": "github"
+      }
+    },
+    "base16-fish": {
       "flake": false,
       "locked": {
-        "lastModified": 1696158499,
-        "narHash": "sha256-5yIHgDTPjoX/3oDEfLSQ0eJZdFL1SaCfb9d6M0RmOTM=",
+        "lastModified": 1765809053,
+        "narHash": "sha256-XCUQLoLfBJ8saWms2HCIj4NEN+xNsWBlU1NrEPcQG4s=",
+        "owner": "tomyun",
+        "repo": "base16-fish",
+        "rev": "86cbea4dca62e08fb7fd83a70e96472f92574782",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tomyun",
+        "repo": "base16-fish",
+        "rev": "86cbea4dca62e08fb7fd83a70e96472f92574782",
+        "type": "github"
+      }
+    },
+    "base16-helix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1760703920,
+        "narHash": "sha256-m82fGUYns4uHd+ZTdoLX2vlHikzwzdu2s2rYM2bNwzw=",
         "owner": "tinted-theming",
-        "repo": "base16-schemes",
-        "rev": "a9112eaae86d9dd8ee6bb9445b664fba2f94037a",
+        "repo": "base16-helix",
+        "rev": "d646af9b7d14bff08824538164af99d0c521b185",
         "type": "github"
       },
       "original": {
         "owner": "tinted-theming",
-        "repo": "base16-schemes",
+        "repo": "base16-helix",
+        "type": "github"
+      }
+    },
+    "base16-vim": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1732806396,
+        "narHash": "sha256-e0bpPySdJf0F68Ndanwm+KWHgQiZ0s7liLhvJSWDNsA=",
+        "owner": "tinted-theming",
+        "repo": "base16-vim",
+        "rev": "577fe8125d74ff456cf942c733a85d769afe58b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "base16-vim",
+        "rev": "577fe8125d74ff456cf942c733a85d769afe58b7",
         "type": "github"
       }
     },
@@ -51,6 +103,22 @@
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "bfbd5014640db4509f601878a2f2a9216a0459d0",
+        "type": "github"
+      }
+    },
+    "firefox-gnome-theme": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775176642,
+        "narHash": "sha256-2veEED0Fg7Fsh81tvVDNYR6SzjqQxa7hbi18Jv4LWpM=",
+        "owner": "rafaelmardojai",
+        "repo": "firefox-gnome-theme",
+        "rev": "179704030c5286c729b5b0522037d1d51341022c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rafaelmardojai",
+        "repo": "firefox-gnome-theme",
         "type": "github"
       }
     },
@@ -82,6 +150,60 @@
       "original": {
         "owner": "nix-community",
         "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "stylix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "fromYaml": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1731966426,
+        "narHash": "sha256-lq95WydhbUTWig/JpqiB7oViTcHFP8Lv41IGtayokA8=",
+        "owner": "SenchoPens",
+        "repo": "fromYaml",
+        "rev": "106af9e2f715e2d828df706c386a685698f3223b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "SenchoPens",
+        "repo": "fromYaml",
+        "type": "github"
+      }
+    },
+    "gnome-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767737596,
+        "narHash": "sha256-eFujfIUQDgWnSJBablOuG+32hCai192yRdrNHTv0a+s=",
+        "owner": "GNOME",
+        "repo": "gnome-shell",
+        "rev": "ef02db02bf0ff342734d525b5767814770d85b49",
+        "type": "github"
+      },
+      "original": {
+        "owner": "GNOME",
+        "repo": "gnome-shell",
+        "rev": "ef02db02bf0ff342734d525b5767814770d85b49",
         "type": "github"
       }
     },
@@ -117,25 +239,6 @@
       "original": {
         "owner": "nix-community",
         "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "nix-colors": {
-      "inputs": {
-        "base16-schemes": "base16-schemes",
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1707825078,
-        "narHash": "sha256-hTfge2J2W+42SZ7VHXkf4kjU+qzFqPeC9k66jAUBMHk=",
-        "owner": "misterio77",
-        "repo": "nix-colors",
-        "rev": "b01f024090d2c4fc3152cd0cf12027a7b8453ba1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "misterio77",
-        "repo": "nix-colors",
         "type": "github"
       }
     },
@@ -196,18 +299,28 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
+    "nur": {
+      "inputs": {
+        "flake-parts": [
+          "stylix",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "stylix",
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1697935651,
-        "narHash": "sha256-qOfWjQ2JQSQL15KLh6D7xQhx0qgZlYZTYlcEiRuAMMw=",
+        "lastModified": 1775228139,
+        "narHash": "sha256-ebbeHmg+V7w8050bwQOuhmQHoLOEOfqKzM1KgCTexK4=",
         "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "e1e11fdbb01113d85c7f41cada9d2847660e3902",
+        "repo": "NUR",
+        "rev": "601971b9c89e0304561977f2c28fa25e73aa7132",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "repo": "nixpkgs.lib",
+        "repo": "NUR",
         "type": "github"
       }
     },
@@ -217,10 +330,10 @@
         "brave-torrent": "brave-torrent",
         "helix-themes": "helix-themes",
         "home-manager": "home-manager",
-        "nix-colors": "nix-colors",
         "nix-darwin": "nix-darwin",
         "nixos-apple-silicon": "nixos-apple-silicon",
         "nixpkgs": "nixpkgs",
+        "stylix": "stylix",
         "x1e-nixos-config": "x1e-nixos-config"
       }
     },
@@ -242,6 +355,118 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "stylix": {
+      "inputs": {
+        "base16": "base16",
+        "base16-fish": "base16-fish",
+        "base16-helix": "base16-helix",
+        "base16-vim": "base16-vim",
+        "firefox-gnome-theme": "firefox-gnome-theme",
+        "flake-parts": "flake-parts",
+        "gnome-shell": "gnome-shell",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nur": "nur",
+        "systems": "systems",
+        "tinted-kitty": "tinted-kitty",
+        "tinted-schemes": "tinted-schemes",
+        "tinted-tmux": "tinted-tmux",
+        "tinted-zed": "tinted-zed"
+      },
+      "locked": {
+        "lastModified": 1776170745,
+        "narHash": "sha256-Tl1aZVP5EIlT+k0+iAKH018GLHJpLz3hhJ0LNQOWxCc=",
+        "owner": "nix-community",
+        "repo": "stylix",
+        "rev": "e3861617645a43c9bbefde1aa6ac54dd0a44bfa9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "stylix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "tinted-kitty": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1735730497,
+        "narHash": "sha256-4KtB+FiUzIeK/4aHCKce3V9HwRvYaxX+F1edUrfgzb8=",
+        "owner": "tinted-theming",
+        "repo": "tinted-kitty",
+        "rev": "de6f888497f2c6b2279361bfc790f164bfd0f3fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "tinted-kitty",
+        "type": "github"
+      }
+    },
+    "tinted-schemes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772661346,
+        "narHash": "sha256-4eu3LqB9tPqe0Vaqxd4wkZiBbthLbpb7llcoE/p5HT0=",
+        "owner": "tinted-theming",
+        "repo": "schemes",
+        "rev": "13b5b0c299982bb361039601e2d72587d6846294",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "schemes",
+        "type": "github"
+      }
+    },
+    "tinted-tmux": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772934010,
+        "narHash": "sha256-x+6+4UvaG+RBRQ6UaX+o6DjEg28u4eqhVRM9kpgJGjQ=",
+        "owner": "tinted-theming",
+        "repo": "tinted-tmux",
+        "rev": "c3529673a5ab6e1b6830f618c45d9ce1bcdd829d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "tinted-tmux",
+        "type": "github"
+      }
+    },
+    "tinted-zed": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772909925,
+        "narHash": "sha256-jx/5+pgYR0noHa3hk2esin18VMbnPSvWPL5bBjfTIAU=",
+        "owner": "tinted-theming",
+        "repo": "base16-zed",
+        "rev": "b4d3a1b3bcbd090937ef609a0a3b37237af974df",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "base16-zed",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,11 @@
       url = "git+https://codeberg.org/LGFae/awww";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    stylix = {
+      url = "github:nix-community/stylix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     helix-themes.url = "github:CptPotato/helix-themes";
-    nix-colors.url = "github:misterio77/nix-colors";
     brave-torrent.url = "github:NixOS/nixpkgs?rev=bfbd5014640db4509f601878a2f2a9216a0459d0";
   };
 
@@ -34,7 +37,7 @@
     , nix-darwin
     , home-manager
     , awww
-    , nix-colors
+    , stylix
     , brave-torrent
     , ...
     }@inputs:
@@ -65,14 +68,14 @@
                 useUserPackages = true;
                 useGlobalPkgs = true;
                 users.${user} = host + "/home-manager";
-                sharedModules = [ inputs.helix-themes.homeManagerModule ];
+                sharedModules = builtins.attrValues self.homeManagerModules;
               };
             }
           ] ++ lib.optional (type == "nixos")
             {
               # TODO: Use hyprpaper and stylix so we can just remove this
               nixpkgs.overlays = [ awww.overlays.default ];
-              home-manager.extraSpecialArgs = { inherit nix-colors brave-torrent; };
+              home-manager.extraSpecialArgs = { inherit brave-torrent; };
             };
         };
 
@@ -91,6 +94,7 @@
     {
       # All user defined home-manager modules go here
       homeManagerModules = {
+        inherit (stylix.homeModules) stylix;
         helix-themes = inputs.helix-themes.homeManagerModule;
       };
 

--- a/users/eureka/home-manager/hyprland.nix
+++ b/users/eureka/home-manager/hyprland.nix
@@ -1,5 +1,12 @@
 { pkgs, config, ... }:
 {
+  stylix = {
+    enable = true;
+    targets.hyprland = {
+      enable = true;
+      colors.enable = true;
+    };
+  };
   wayland.windowManager.hyprland = {
     enable = true;
     settings =

--- a/users/eureka/nixos/configurations/critter-tank/home-manager/default.nix
+++ b/users/eureka/nixos/configurations/critter-tank/home-manager/default.nix
@@ -1,10 +1,9 @@
-{ pkgs, nix-colors, ... }:
+{ pkgs, ... }:
 {
   imports = [
     ./gtk.nix
     ../../../../home-manager/hyprland.nix
     ../../../../home-manager/default.nix
-    nix-colors.homeManagerModules.default
   ];
 
   home.packages = with pkgs; [

--- a/users/eureka/nixos/configurations/critter-tank/home-manager/default.nix
+++ b/users/eureka/nixos/configurations/critter-tank/home-manager/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 {
   imports = [
     ./gtk.nix
@@ -13,11 +13,11 @@
   programs.kitty = {
     themeFile = "GruvboxMaterialDarkMedium";
     font = {
-      name = "JetBrainsMono Nerd Font";
-      size = 15;
+      name = lib.mkForce "JetBrainsMono Nerd Font";
+      size = lib.mkForce 15;
     };
   };
-  programs.helix.settings.theme = "gruvbox_material_dark_medium";
+  programs.helix.settings.theme = lib.mkForce "gruvbox_material_dark_medium";
 
   # This value determines the Home Manager release that your configuration is
   # compatible with. This helps avoid breakage when a new Home Manager release

--- a/users/eureka/nixos/configurations/critter-tank/home-manager/gtk.nix
+++ b/users/eureka/nixos/configurations/critter-tank/home-manager/gtk.nix
@@ -1,19 +1,14 @@
-{ pkgs, nix-colors, ... }:
+{ pkgs, ... }:
 let
-  inherit (nix-colors.lib-contrib { inherit pkgs; }) gtkThemeFromScheme;
   cursorName = "Adwaita";
   cursorPkg = pkgs.adwaita-icon-theme;
   cursorSize = 20;
-  colorScheme = nix-colors.colorSchemes.gruvbox-material-dark-medium;
 in
 {
+  stylix.base16Scheme = "${pkgs.base16-schemes}/share/themes/gruvbox-material-dark-medium.yaml";
+
   gtk = {
     enable = true;
-    theme = {
-      name = "${colorScheme.slug}";
-      package = gtkThemeFromScheme { scheme = colorScheme; };
-    };
-
     iconTheme = {
       name = "Gruvbox-Plus-Dark";
       package = pkgs.gruvbox-plus-icons;

--- a/users/eureka/nixos/configurations/critter-tank/home-manager/gtk.nix
+++ b/users/eureka/nixos/configurations/critter-tank/home-manager/gtk.nix
@@ -5,13 +5,22 @@ let
   cursorSize = 20;
 in
 {
-  stylix.base16Scheme = "${pkgs.base16-schemes}/share/themes/gruvbox-material-dark-medium.yaml";
+  stylix = {
+    base16Scheme = "${pkgs.base16-schemes}/share/themes/gruvbox-material-dark-medium.yaml";
+    targets = {
+      gtk.enable = true;
+      gtk.colors.enable = true;
+      qt.enable = true;
+    };
+  };
 
   gtk = {
     enable = true;
     iconTheme = {
       name = "Gruvbox-Plus-Dark";
-      package = pkgs.gruvbox-plus-icons;
+      package = pkgs.gruvbox-plus-icons.override {
+        folder-color = "white";
+      };
     };
     cursorTheme = {
       name = cursorName;

--- a/users/eureka/nixos/configurations/yabai/home-manager/default.nix
+++ b/users/eureka/nixos/configurations/yabai/home-manager/default.nix
@@ -1,10 +1,9 @@
-{ pkgs, nix-colors, ... }:
+{ pkgs, ... }:
 {
   imports = [
     ./gtk.nix
     ../../../../home-manager/hyprland.nix
     ../../../../home-manager/default.nix
-    nix-colors.homeManagerModules.default
   ];
 
   home.packages = with pkgs; [

--- a/users/eureka/nixos/configurations/yabai/home-manager/gtk.nix
+++ b/users/eureka/nixos/configurations/yabai/home-manager/gtk.nix
@@ -5,7 +5,14 @@ let
   cursorSize = 22;
 in
 {
-  stylix.base16Scheme = "${pkgs.base16-schemes}/share/themes/gruvbox-material-dark-medium.yaml";
+  stylix = {
+    base16Scheme = "${pkgs.base16-schemes}/share/themes/gruvbox-material-dark-medium.yaml";
+    targets = {
+      gtk.enable = true;
+      gtk.colors.enable = true;
+      qt.enable = true;
+    };
+  };
 
   gtk = {
     enable = true;

--- a/users/eureka/nixos/configurations/yabai/home-manager/gtk.nix
+++ b/users/eureka/nixos/configurations/yabai/home-manager/gtk.nix
@@ -1,19 +1,14 @@
-{ pkgs, nix-colors, ... }:
+{ pkgs, ... }:
 let
-  inherit (nix-colors.lib-contrib { inherit pkgs; }) gtkThemeFromScheme;
   cursorName = "Adwaita";
   cursorPkg = pkgs.adwaita-icon-theme;
   cursorSize = 22;
-  colorScheme = nix-colors.colorSchemes.gruvbox-material-dark-medium;
 in
 {
+  stylix.base16Scheme = "${pkgs.base16-schemes}/share/themes/gruvbox-material-dark-medium.yaml";
+
   gtk = {
     enable = true;
-    theme = {
-      name = "${colorScheme.slug}";
-      package = gtkThemeFromScheme { scheme = colorScheme; };
-    };
-
     iconTheme = {
       name = "Gruvbox-Plus-Dark";
       package = pkgs.gruvbox-plus-icons;


### PR DESCRIPTION
Closes #23 

nix-colors is outdated to the point it no longer compiles, and it also no longer follows the pattern established by the flake so it should be removed and replaced with something that is maintained like stylix.